### PR TITLE
Improved RequestManager call

### DIFF
--- a/RequestManagers/CurlRequestManager.php
+++ b/RequestManagers/CurlRequestManager.php
@@ -213,6 +213,8 @@ class CurlRequestManager implements IRequestManager
         curl_setopt($ch, CURLOPT_URL, $this->getBaseUrl() . $path);
         curl_setopt($ch, CURLOPT_PORT, $this->getPort());
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        // Setting timeout that throws exception when the PushApi is down
+        curl_setopt($ch, CURLOPT_TIMEOUT, 2000);
 
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
 


### PR DESCRIPTION
Adding call timeout to the Curl RequestManager in order to detect when the api is down and receive an exception